### PR TITLE
GSREN3D-179 Line routing direct access

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, provide, ref } from 'vue'
+import { onMounted, onUnmounted, provide } from 'vue'
 import { CesiumMap, Context, VcsApp, Layer, FeatureLayer } from '@vcmap/core'
 
 import UiMap from '@/components/ui/UiMap.vue'
@@ -27,7 +27,6 @@ import { trambusStopStyle } from '@/styles/trambusStop'
 const vcsApp = new VcsApp()
 provide('vcsApp', vcsApp)
 
-const appLoaded = ref(false)
 const layerStore = useLayersStore()
 const mapStore = useMapStore()
 const lineViewStore = useLineViewsStore()
@@ -42,8 +41,8 @@ onMounted(async () => {
   if (cesiumMap && cesiumMap instanceof CesiumMap) {
     cesiumMap.getScene().globe.maximumScreenSpaceError = 1
   }
-  appLoaded.value = true
   // window.vcmap = vcsApp
+  mapStore.updateViewpoint(`home`, true)
   await updateLayersVisibility()
   updateMapStyle()
 })
@@ -235,6 +234,6 @@ travelTimesViewStore.$subscribe(async () => {
 </script>
 
 <template>
-  <UiMap v-if="appLoaded"></UiMap>
+  <UiMap></UiMap>
   <NavigationButtons />
 </template>

--- a/src/views/LineView.vue
+++ b/src/views/LineView.vue
@@ -61,9 +61,7 @@ onMounted(async () => {
     layerStore.visibilities.rennesOrtho = false
   }
   // Set vcs app view point
-  setTimeout(() => {
-    mapStore.updateViewpoint(`line${lineStore.selectedLine}`, true)
-  }, 500)
+  mapStore.updateViewpoint(`line${lineStore.selectedLine}`, true)
 })
 
 function backButtonClicked() {


### PR DESCRIPTION
(!) Do not merge

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-179

### Description

@ismailsunni there is a little bug on https://github.com/sigrennesmetropole/cooperation_jn_app/pull/5
When you try to access directly line/:id, background map doesn't load so I fix it.

More problematic: the zoom to the viewpoint of the line when direct access is not working. I think the vcs map is not loaded yet, so the goToViewpoint is uneffective. 

The solution of a setTimeout (which is working here) is bad (so do not merge!), this is just for the showcase.
Did you encounter something similar? Do we have something for wait the vcsmap to be loaded before calling gotoviewpoint?
