### PR TITLE
GSREN3D-279: Add eyeOfSet to make sure the parking billboard is always seen.

### DIFF
--- a/src/map.config.json
+++ b/src/map.config.json
@@ -203,7 +203,10 @@
       "url": "https://public.sig.rennesmetropole.fr/geoserver/ows?service=WFS&request=getFeature&typename=trp_coll:trambus_parc_relais&outputFormat=application/json&srsName=EPSG:4326",
       "type": "GeoJSONLayer",
       "activeOnStartup": true,
-      "zIndex": 4
+      "zIndex": 4,
+      "vectorProperties": {
+        "eyeOffset": [0, 0, -100]
+      }
     },
     {
       "name": "poi",

--- a/src/map.config.json
+++ b/src/map.config.json
@@ -216,7 +216,8 @@
       "zIndex": 4,
       "vectorProperties": {
         "altitudeMode": "relativeToGround",
-        "heightAboveGround": 5
+        "heightAboveGround": 5,
+        "eyeOffset": [0, 0, -100]
       }
     },
     {


### PR DESCRIPTION
<!-- Title must be: GSREN3D-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-279

### Description

- Set the eyeOfSet properties of the parking layer. See more here: See: https://cesium.com/learn/cesiumjs/ref-doc/BillboardGraphics.html#eyeOffset

### Screenshots

Before and After

![20230206_103620 - eyeoffset](https://user-images.githubusercontent.com/1421861/216878492-854fae99-875f-4975-937b-29bdafbed112.png)


