### PR TITLE
GSREN3D-208: render station as disk

### DIFF
--- a/src/map.config.json
+++ b/src/map.config.json
@@ -195,6 +195,55 @@
           }
         }
       },
+      "vectorProperties": {
+        "primitiveOptions": {
+          "type": "cylinder",
+          "geometryOptions": {
+            "length": 1.0,
+            "topRadius": 5.0,
+            "bottomRadius": 5.0,
+            "outline": false,
+            "material": "Cesium.Color.GREEN"
+          },
+          "offset": [0, 0, 0.1]
+        },
+        "modelAutoScale": true
+      },
+      "activeOnStartup": false,
+      "zIndex": 5
+    },
+    {
+      "name": "_trambusStopsOutline",
+      "url": "https://public.sig.rennesmetropole.fr/geoserver/ows?service=WFS&request=getFeature&typename=trp_coll:trambus_arrets&outputFormat=application/json&srsName=EPSG:4326",
+      "type": "GeoJSONLayer",
+      "style": {
+        "name": "trambusStopOutlineStyle",
+        "type": "VectorStyleItem",
+        "image": {
+          "radius": 3,
+          "fill": {
+            "color": "#fff"
+          },
+          "stroke": {
+            "color": "#000",
+            "width": "1.5"
+          }
+        }
+      },
+      "vectorProperties": {
+        "primitiveOptions": {
+          "type": "cylinder",
+          "geometryOptions": {
+            "length": 0.99,
+            "topRadius": 6.5,
+            "bottomRadius": 6.5,
+            "outline": false,
+            "material": "Cesium.Color.WHITE"
+          },
+          "offset": [0, 0, 0.1]
+        },
+        "modelAutoScale": true
+      },
       "activeOnStartup": false,
       "zIndex": 5
     },

--- a/src/services/viewStyle.ts
+++ b/src/services/viewStyle.ts
@@ -14,6 +14,7 @@ import {
   trambusStopLineViewStyleFunction,
   trambusStopOutlineTravelTimesViewStyleFunction,
   trambusStopTravelTimesViewStyleFunction,
+  trambusStopOutlineLineViewStyleFunction,
 } from '@/styles/trambusStop'
 import { isTrambusStopBelongsToLine } from '@/services/station'
 import { parkingStyle, poiStyle } from '@/styles/common'
@@ -50,6 +51,17 @@ export async function updateLineViewStyle(rennesApp: RennesApp) {
       isTrambusStopBelongsToLine(feature, lineViewStore.selectedLine),
       mapStore.is3D()
     )
+  )
+  clearLayerAndApplyStyle(
+    rennesApp,
+    RENNES_LAYER._trambusStopsOutline,
+    (feature) =>
+      trambusStopOutlineLineViewStyleFunction(
+        feature,
+        lineViewStore.selectedLine,
+        isTrambusStopBelongsToLine(feature, lineViewStore.selectedLine),
+        mapStore.is3D()
+      )
   )
   clearLayerAndApplyStyle(rennesApp, RENNES_LAYER.parking, parkingStyle)
   await updateTraveltimeArrow(rennesApp)
@@ -103,6 +115,17 @@ export async function updateStationViewStyle(rennesApp: RennesApp) {
       isTrambusStopBelongsToLine(feature, lineViewStore.selectedLine),
       mapStore.is3D()
     )
+  )
+  clearLayerAndApplyStyle(
+    rennesApp,
+    RENNES_LAYER._trambusStopsOutline,
+    (feature) =>
+      trambusStopOutlineLineViewStyleFunction(
+        feature,
+        lineViewStore.selectedLine,
+        isTrambusStopBelongsToLine(feature, lineViewStore.selectedLine),
+        mapStore.is3D()
+      )
   )
   clearLayerAndApplyStyle(rennesApp, RENNES_LAYER.poi, poiStyle)
 }

--- a/src/services/viewStyle.ts
+++ b/src/services/viewStyle.ts
@@ -3,11 +3,14 @@ import type { StyleFunction } from 'ol/style/Style'
 import type { Style } from 'ol/style'
 import type { FeatureLayer } from '@vcmap/core'
 import type { RennesApp } from '@/services/RennesApp'
-import { trambusLineViewStyleFunction } from '@/styles/line'
+import {
+  trambusLineViewStyleFunction,
+  trambusLineTravelTimesViewStyleFunction,
+} from '@/styles/line'
+
 import { useMapStore } from '@/stores/map'
 import { useLineViewsStore } from '@/stores/views'
 import {
-  trambusLineTravelTimesViewStyleFunction,
   trambusStopLineViewStyleFunction,
   trambusStopTravelTimesViewStyleFunction,
 } from '@/styles/trambusStop'

--- a/src/services/viewStyle.ts
+++ b/src/services/viewStyle.ts
@@ -12,6 +12,7 @@ import { useMapStore } from '@/stores/map'
 import { useLineViewsStore } from '@/stores/views'
 import {
   trambusStopLineViewStyleFunction,
+  trambusStopOutlineTravelTimesViewStyleFunction,
   trambusStopTravelTimesViewStyleFunction,
 } from '@/styles/trambusStop'
 import { isTrambusStopBelongsToLine } from '@/services/station'
@@ -70,6 +71,16 @@ export async function updateTravelTimesViewStyle(rennesApp: RennesApp) {
       traveltimeInteractionStore.selectedTraveltime!,
       mapStore.is3D()
     )
+  )
+  clearLayerAndApplyStyle(
+    rennesApp,
+    RENNES_LAYER._trambusStopsOutline,
+    (feature) =>
+      trambusStopOutlineTravelTimesViewStyleFunction(
+        feature,
+        traveltimeInteractionStore.selectedTraveltime!,
+        mapStore.is3D()
+      )
   )
   await updateTraveltimeArrow(rennesApp)
 }

--- a/src/stores/layers.ts
+++ b/src/stores/layers.ts
@@ -15,6 +15,7 @@ export const RENNES_LAYER = {
   // The following layers are scratch layers
   _traveltimeArrow: '_traveltimeArrow',
   customLayerLabelLine: 'customLayerLabelLine',
+  _trambusStopsOutline: '_trambusStopsOutline',
 }
 
 export const RENNES_LAYERNAMES = [
@@ -29,6 +30,7 @@ export const RENNES_LAYERNAMES = [
   RENNES_LAYER.poi,
   RENNES_LAYER._traveltimeArrow,
   RENNES_LAYER.customLayerLabelLine,
+  RENNES_LAYER._trambusStopsOutline,
 ] as const
 
 export type RennesLayer = typeof RENNES_LAYERNAMES[number]
@@ -46,6 +48,7 @@ export const useLayersStore = defineStore('layers', () => {
     parking: false,
     poi: false,
     _traveltimeArrow: false,
+    _trambusStopsOutline: false,
   })
 
   function toggleLayer(name: RennesLayer) {
@@ -73,6 +76,8 @@ export const useLayersStore = defineStore('layers', () => {
     update3DBaseLayer(is3D)
     visibilities.value.trambusLines = newVisibilities.trambusLines
     visibilities.value.trambusStops = newVisibilities.trambusStops
+    // Set the "fake" layer for trambus stops outline to the same as the trambus stop
+    visibilities.value._trambusStopsOutline = newVisibilities.trambusStops
     visibilities.value.parking = newVisibilities.parking
     visibilities.value.poi = newVisibilities.poi
     visibilities.value._traveltimeArrow = newVisibilities._traveltimeArrow

--- a/src/styles/line.ts
+++ b/src/styles/line.ts
@@ -3,6 +3,7 @@ import { Stroke, Style } from 'ol/style'
 import { getTrambusLineNumber, lineColors, lineDimmedColors } from './common'
 import type { FeatureLike } from 'ol/Feature'
 import { SelectedTrambusLine } from '@/model/selected-line.model'
+import type { TravelTimeModel } from '@/model/travel-time.model'
 
 export type LineState = 'selected' | 'normal' | 'unselected' | 'hidden'
 
@@ -71,6 +72,24 @@ export function trambusLineViewStyleFunction(
     lineState = 'selected'
   } else {
     lineState = displayOtherLine ? 'unselected' : 'hidden'
+  }
+  return trambusLineStyle(lineNumber, lineState, is3D)
+}
+
+export function trambusLineTravelTimesViewStyleFunction(
+  feature: FeatureLike,
+  selectedTravelTime: TravelTimeModel,
+  is3D: boolean
+): Style[] {
+  const lineNumber = getTrambusLineNumber(feature) as LineNumber
+  let lineState: LineState = 'normal'
+
+  if (selectedTravelTime == null) {
+    lineState = 'normal'
+  } else if (getTrambusLineNumber(feature) == selectedTravelTime.line) {
+    lineState = 'selected'
+  } else {
+    lineState = 'unselected'
   }
   return trambusLineStyle(lineNumber, lineState, is3D)
 }

--- a/src/styles/trambusStop.ts
+++ b/src/styles/trambusStop.ts
@@ -15,7 +15,8 @@ function getCircleStyle(
   let fillColor = ol_color.fromString('#FFFFFF')
   let strokeColor = lineColors[lineNumber]
 
-  // TODO: change to use disk style
+  // Only handle the color of the 3D style here, disk is configured by
+  // vector properties of the layer
   if (is3D) {
     fillColor = ol_color.fromString('#FFFFFF')
     strokeColor = lineColors[lineNumber]
@@ -64,6 +65,8 @@ export function trambusStopStyle(
   return [circleStyle]
 }
 
+// The only way until now to created a disk with a proper border, we render the same trambus layer
+//  but using the same color as the stroke color
 export function trambusStopOutlineStyle(
   lineNumber: LineNumber,
   isShown: boolean,
@@ -74,8 +77,10 @@ export function trambusStopOutlineStyle(
     return []
   }
   let radius = 6
+  // TODO: it seems this radius is not used if we user vector properties, need to remove it or
+  // somehow set a new value for the vector properties of the layer
   if (isSelectedStation) {
-    radius = 6
+    radius = 8
   }
   const outline_style = new Style({
     image: new Circle({

--- a/src/styles/trambusStop.ts
+++ b/src/styles/trambusStop.ts
@@ -3,8 +3,6 @@ import { Circle, Fill, Stroke, Style } from 'ol/style'
 import { getTrambusLineNumber, lineColors } from './common'
 import * as ol_color from 'ol/color'
 import type { FeatureLike } from 'ol/Feature'
-import type { LineState } from '@/styles/line'
-import { trambusLineStyle } from '@/styles/line'
 import { getAllStartEndStations } from '@/model/lines.fixtures'
 import type { TravelTimeModel } from '@/model/travel-time.model'
 import { isStationLabelDisplayed } from '@/services/station'
@@ -64,24 +62,6 @@ export function trambusStopStyle(
   }
   const circleStyle = getCircleStyle(lineNumber, isSelectedStation, is3D)
   return [circleStyle]
-}
-
-export function trambusLineTravelTimesViewStyleFunction(
-  feature: FeatureLike,
-  selectedTravelTime: TravelTimeModel,
-  is3D: boolean
-): Style[] {
-  const lineNumber = getTrambusLineNumber(feature) as LineNumber
-  let lineState: LineState = 'normal'
-
-  if (selectedTravelTime == null) {
-    lineState = 'normal'
-  } else if (getTrambusLineNumber(feature) == selectedTravelTime.line) {
-    lineState = 'selected'
-  } else {
-    lineState = 'unselected'
-  }
-  return trambusLineStyle(lineNumber, lineState, is3D)
 }
 
 export function trambusStopTravelTimesViewStyleFunction(

--- a/src/styles/trambusStop.ts
+++ b/src/styles/trambusStop.ts
@@ -163,3 +163,20 @@ export function trambusStopLineViewStyleFunction(
     isStationLabelDisplayed(stationName)
   )
 }
+
+export function trambusStopOutlineLineViewStyleFunction(
+  feature: FeatureLike,
+  selectedLine: number,
+  isShown: boolean,
+  is3D: boolean
+): Style[] {
+  const selectedTrambusLine = Number(selectedLine) as LineNumber
+  const stationName = feature.get('nom')
+
+  return trambusStopOutlineStyle(
+    selectedTrambusLine,
+    isShown,
+    is3D,
+    isStationLabelDisplayed(stationName)
+  )
+}

--- a/src/styles/trambusStop.ts
+++ b/src/styles/trambusStop.ts
@@ -17,8 +17,8 @@ function getCircleStyle(
 
   // TODO: change to use disk style
   if (is3D) {
-    fillColor = lineColors[lineNumber]
-    strokeColor = ol_color.fromString('#FFFFFF')
+    fillColor = ol_color.fromString('#FFFFFF')
+    strokeColor = lineColors[lineNumber]
   }
 
   const fill = new Fill({
@@ -64,6 +64,38 @@ export function trambusStopStyle(
   return [circleStyle]
 }
 
+export function trambusStopOutlineStyle(
+  lineNumber: LineNumber,
+  isShown: boolean,
+  is3D: boolean,
+  isSelectedStation: boolean
+) {
+  if (!is3D || !isShown) {
+    return []
+  }
+  let radius = 6
+  if (isSelectedStation) {
+    radius = 6
+  }
+  const outline_style = new Style({
+    image: new Circle({
+      fill: new Fill({ color: lineColors[lineNumber] }),
+      stroke: new Stroke({
+        color: lineColors[lineNumber],
+        width: 0,
+      }),
+      radius: radius,
+    }),
+    fill: new Fill({ color: lineColors[lineNumber] }),
+    stroke: new Stroke({
+      color: lineColors[lineNumber],
+      width: 0,
+    }),
+    zIndex: 5,
+  })
+  return [outline_style]
+}
+
 export function trambusStopTravelTimesViewStyleFunction(
   feature: FeatureLike,
   selectedTravelTime: TravelTimeModel,
@@ -83,6 +115,31 @@ export function trambusStopTravelTimesViewStyleFunction(
   const isShown = shownStations.indexOf(stationName) > -1
 
   return trambusStopStyle(
+    lineNumber,
+    isShown,
+    is3D,
+    isStationLabelDisplayed(stationName)
+  )
+}
+
+export function trambusStopOutlineTravelTimesViewStyleFunction(
+  feature: FeatureLike,
+  selectedTravelTime: TravelTimeModel,
+  is3D: boolean
+) {
+  let lineNumber = getTrambusLineNumber(feature) as LineNumber
+
+  // no travel time selected, only show the start and end stations
+  let shownStations = getAllStartEndStations()
+  // There is a travel time selected, show only the selected station from
+  // the selected travel time
+  if (selectedTravelTime != null) {
+    shownStations = [selectedTravelTime.start, selectedTravelTime.end]
+    lineNumber = selectedTravelTime?.line
+  }
+  const stationName = feature.get('nom')
+  const isShown = shownStations.indexOf(stationName) > -1
+  return trambusStopOutlineStyle(
     lineNumber,
     isShown,
     is3D,


### PR DESCRIPTION
<!-- Title must be: GSREN3D-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-208

### Description

- Render the station as a disk (cylinder) in travel time, line, and station page

I feel the performance when opening line view is a little bit slow, perhaps because of the many POI loaded (?)

### Screenshots

Travel time view:
![20230207_141849 - disk rendering travel time view](https://user-images.githubusercontent.com/1421861/217174707-6b9ab248-8d78-4aee-85a1-74e485fc9cae.png)

Travel time view with selected travel time:
![20230207_141745 - disk rendering selected travel time](https://user-images.githubusercontent.com/1421861/217174529-e22ecd8a-31ee-48a2-a9d6-4944046ff266.png)

Disk rendering on the line view:
![20230207_141953 - disk rendering on line view](https://user-images.githubusercontent.com/1421861/217174904-5fe0f320-b629-4bbc-a582-c79c4db56cca.png)

Disk rendering on station view:
![20230207_142119 - disk rendering on station view](https://user-images.githubusercontent.com/1421861/217175420-4c185760-24e3-44d8-a806-73df6c8378a0.png)

