### PR TITLE
GSREN3D-316: Timeline dot clickable

### DIFF
--- a/src/components/ui/UiTimeline.vue
+++ b/src/components/ui/UiTimeline.vue
@@ -83,7 +83,11 @@ const setselectedIndex = (index: number) => {
             : 'justify-center',
         ]"
       >
-        <div class="h-2 w-2 bg-gray-400 rounded-full"></div>
+        <div
+          role="button"
+          class="h-2 w-2 bg-gray-400 rounded-full"
+          @click="() => setselectedIndex(index)"
+        ></div>
       </div>
     </div>
     <div

--- a/src/components/ui/UiTimeline.vue
+++ b/src/components/ui/UiTimeline.vue
@@ -64,14 +64,14 @@ const setselectedIndex = (index: number) => {
       v-for="(item, index) of items"
       class="flex-1 flex justify-center items-center relative pb-4 hover:font-medium w-24"
     >
-      <div
-        class="text-center cursor-pointer text-sm leading-5 color-black"
+      <button
+        class="text-center text-sm leading-5 color-black"
         v-bind:class="[selectedIndex === index ? 'font-bold' : 'font-normal']"
         @click="() => setselectedIndex(index)"
       >
         Semestre {{ item.semester }} <br />
         {{ item.year }}
-      </div>
+      </button>
       <div
         class="h-[0.05rem] w-full mt-4 bg-gray-400 flex items-center absolute bottom-8"
         v-bind:class="[
@@ -83,11 +83,11 @@ const setselectedIndex = (index: number) => {
             : 'justify-center',
         ]"
       >
-        <div
+        <button
           role="button"
           class="h-2 w-2 bg-gray-400 rounded-full"
           @click="() => setselectedIndex(index)"
-        ></div>
+        ></button>
       </div>
     </div>
     <div

--- a/src/stores/planning.ts
+++ b/src/stores/planning.ts
@@ -4,7 +4,7 @@ import { defineStore } from 'pinia'
 import type { LinePlanningStateTypes } from '@/model/line-planning-state.model'
 
 export const usePlanningStore = defineStore('planning', () => {
-  const selectedYear: Ref<number> = ref(2029)
+  const selectedYear: Ref<number> = ref(2025)
   const selectedSemester: Ref<number> = ref(1)
   const selectedLineState: Ref<LinePlanningStateTypes | null> = ref(null)
   const selectedLine: Ref<number> = ref(0)


### PR DESCRIPTION
<!-- Title must be: GSREN3D-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-316

### Description

- Make dot clickable
- Start the date from 2025 semester 1
- Use proper button tag

### Screenshots

![Peek 2023-02-20 16-09 - clickable dot timeline](https://user-images.githubusercontent.com/1421861/220061958-8b464d8e-34bf-45b1-a7ca-4c08a6dd983a.gif)


(only if the final render is different)
