### PR TITLE
GSREN3D-292 : Accessibility home

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@pinia/testing": "^0.0.14",
-        "@sigrennesmetropole/cooperation_jn_common_ui": "0.0.8",
+        "@sigrennesmetropole/cooperation_jn_common_ui": "0.0.9",
         "@vcmap/cesium": "^1.97.1",
         "@vcmap/core": "^5.0.0-rc.26",
         "node-fetch": "^3.3.0",
@@ -1523,9 +1523,9 @@
       "dev": true
     },
     "node_modules/@sigrennesmetropole/cooperation_jn_common_ui": {
-      "version": "0.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@sigrennesmetropole/cooperation_jn_common_ui/0.0.8/24ef4026266a05eb4a67602bf313608131678eca",
-      "integrity": "sha512-xTXcHkF3agbMEjpMUSwADapaRysZRUWPkq2jJ7G9ECPpEFL5Ibr/YXc9t3iA+C/cW2474E9KfR9JVozZoGwK9Q==",
+      "version": "0.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@sigrennesmetropole/cooperation_jn_common_ui/0.0.9/ef88839198da1514aefbea3c2aa898c2c9809367",
+      "integrity": "sha512-DILKq4QdxPBOXMklFtn9QTgMa3zxiuNeW/FBtCtOdW9mHAqFl698mLGqHv+yemL8r5fHPojl68hdQ236Ux1d/w==",
       "dependencies": {
         "npm-watch": "^0.11.0",
         "vue": "^3.2.38"
@@ -12567,9 +12567,9 @@
       "dev": true
     },
     "@sigrennesmetropole/cooperation_jn_common_ui": {
-      "version": "0.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@sigrennesmetropole/cooperation_jn_common_ui/0.0.8/24ef4026266a05eb4a67602bf313608131678eca",
-      "integrity": "sha512-xTXcHkF3agbMEjpMUSwADapaRysZRUWPkq2jJ7G9ECPpEFL5Ibr/YXc9t3iA+C/cW2474E9KfR9JVozZoGwK9Q==",
+      "version": "0.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@sigrennesmetropole/cooperation_jn_common_ui/0.0.9/ef88839198da1514aefbea3c2aa898c2c9809367",
+      "integrity": "sha512-DILKq4QdxPBOXMklFtn9QTgMa3zxiuNeW/FBtCtOdW9mHAqFl698mLGqHv+yemL8r5fHPojl68hdQ236Ux1d/w==",
       "requires": {
         "npm-watch": "^0.11.0",
         "vue": "^3.2.38"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@pinia/testing": "^0.0.14",
-    "@sigrennesmetropole/cooperation_jn_common_ui": "0.0.8",
+    "@sigrennesmetropole/cooperation_jn_common_ui": "0.0.9",
     "@vcmap/cesium": "^1.97.1",
     "@vcmap/core": "^5.0.0-rc.26",
     "node-fetch": "^3.3.0",

--- a/src/components/accessibility/SkipLinks.vue
+++ b/src/components/accessibility/SkipLinks.vue
@@ -6,21 +6,20 @@ const props = defineProps<{
 }>()
 </script>
 <template>
-  <div class="fr-skiplinks">
-    <nav class="fr-container" role="navigation" aria-label="Accès rapide">
-      <ul class="fr-skiplinks__list">
-        <li v-for="link in props.links" :key="link.id">
-          <a :href="'#' + link.id" class="fr-link bg-white p-1">
-            {{ link.title }}
-          </a>
-        </li>
-      </ul>
-    </nav>
-  </div>
+  <nav role="navigation" aria-label="Accès rapide">
+    <ul>
+      <li v-for="link in props.links" :key="link.id">
+        <a :href="'#' + link.id" class="fr-link bg-white p-1">
+          {{ link.title }}
+        </a>
+      </li>
+    </ul>
+  </nav>
 </template>
 <style scoped>
 .fr-link {
   position: absolute;
+  z-index: 100;
   transform: translateY(-1000%);
 }
 

--- a/src/components/accessibility/SkipLinks.vue
+++ b/src/components/accessibility/SkipLinks.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+// https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/liens-d-evitement/
+
+const props = defineProps<{
+  links: { id: string; title: string }[]
+}>()
+</script>
+<template>
+  <div class="fr-skiplinks">
+    <nav class="fr-container" role="navigation" aria-label="Accès rapide">
+      <ul class="fr-skiplinks__list">
+        <li v-for="link in props.links" :key="link.id">
+          <a :href="'#' + link.id" class="fr-link bg-white p-1">
+            {{ link.title }}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</template>
+<style scoped>
+.fr-link {
+  position: absolute;
+  transform: translateY(-1000%);
+}
+
+.fr-link:focus {
+  transform: translateY(0%);
+}
+</style>

--- a/src/components/accessibility/SkipLinksHome.vue
+++ b/src/components/accessibility/SkipLinksHome.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import SkipLinks from '@/components/accessibility/SkipLinks.vue'
 const links = [
-  { id: 'reseau-trambus', title: 'Réseau trambus' },
   { id: 'travel-times', title: 'Temps de parcours théorique' },
   { id: 'line-descriptions', title: 'Les nouvelles lignes' },
-  { id: 'planning-project', title: 'Planning du projet' },
+  { id: 'head-toolbar', title: 'Barre de navigation carte' },
   { id: 'footer', title: 'Pied de page' },
 ]
 </script>

--- a/src/components/accessibility/SkipLinksHome.vue
+++ b/src/components/accessibility/SkipLinksHome.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import SkipLinks from '@/components/accessibility/SkipLinks.vue'
+const links = [
+  { id: 'reseau-trambus', title: 'Réseau trambus' },
+  { id: 'travel-times', title: 'Temps de parcours théorique' },
+  { id: 'line-descriptions', title: 'Les nouvelles lignes' },
+  { id: 'planning-project', title: 'Planning du projet' },
+  { id: 'footer', title: 'Pied de page' },
+]
+</script>
+<template>
+  <SkipLinks :links="links" />
+</template>

--- a/src/components/home/LineDescriptions.vue
+++ b/src/components/home/LineDescriptions.vue
@@ -44,7 +44,10 @@ function leaveLine() {
     <h2 class="font-dm-sans font-bold text-lg leading-6">
       Les nouvelles lignes
     </h2>
-    <div class="flex flex-col p-0 gap-2 grow">
+    <ul
+      class="flex flex-col p-0 gap-2 grow"
+      aria-label="Liste des nouvelles lignes"
+    >
       <UiLineDescription
         v-for="lineDescription in state.lineDescription"
         role="button"
@@ -60,6 +63,6 @@ function leaveLine() {
         :frequency="lineDescription.frequency"
       >
       </UiLineDescription>
-    </div>
+    </ul>
   </div>
 </template>

--- a/src/components/home/LineDescriptions.vue
+++ b/src/components/home/LineDescriptions.vue
@@ -40,7 +40,7 @@ function leaveLine() {
 </script>
 
 <template>
-  <section class="flex flex-col p-0 gap-2">
+  <div class="flex flex-col p-0 gap-2">
     <h2 class="font-dm-sans font-bold text-lg leading-6">
       Les nouvelles lignes
     </h2>
@@ -61,5 +61,5 @@ function leaveLine() {
       >
       </UiLineDescription>
     </div>
-  </section>
+  </div>
 </template>

--- a/src/components/home/SidePanel.vue
+++ b/src/components/home/SidePanel.vue
@@ -29,6 +29,7 @@ const leftAlignment = computed(() =>
         :is-open="panelStore.isInformationPanelShown"
         @click="toggleInformationPanel"
         :class="leftAlignment"
+        ariaLabelButton="Rétracter le panneau latéral pour afficher la carte sur tout l'écran"
       ></UiPanelControlButton>
     </div>
   </div>

--- a/src/components/home/TravelTimes.vue
+++ b/src/components/home/TravelTimes.vue
@@ -36,7 +36,10 @@ onMounted(async () => {
 
   <div class="flex flex-col items-start gap-3 pt-0 pr-9 pb-0 pl-0">
     <UiOverflowContainer class="w-[450px] -mx-6">
-      <div class="flex flex-row items-start gap-2 w-[450px]">
+      <ul
+        class="flex flex-row items-start gap-2 w-[450px]"
+        title="Liste des temps de parcours"
+      >
         <UiTravelTime
           class="w-80 flex-none"
           v-for="travelTime in state.travelTimes"
@@ -48,14 +51,14 @@ onMounted(async () => {
           :endStation="travelTime.end"
         >
         </UiTravelTime>
-      </div>
+      </ul>
     </UiOverflowContainer>
 
     <UiLinkPrimary
       :url="'/traveltimes'"
       :arrowStrokeColor="'stroke-red-600'"
       :underlineColor="'bg-red-600'"
-      :title="'Voir plus de futurs temps de parcours'"
+      :aria-label="'Voir plus de futurs temps de parcours'"
     >
       Voir plus
     </UiLinkPrimary>

--- a/src/components/map/HeadToolbarTrambus.vue
+++ b/src/components/map/HeadToolbarTrambus.vue
@@ -63,6 +63,8 @@ function activeAllTrambusLine() {
         type="button"
         class="rounded-l-lg px-3 py-3 border border-gray-200 bg-white text-gray-900 inline-flex items-center"
         v-if="isTrambusButtonVisible"
+        titleButton="Afficher les autres lignes de trambus"
+        ariaLabelButton="Afficher les autres lignes de trambus sur la carte"
       >
         <IconTB :active="lineStore.displayedOtherLines"></IconTB>
       </UiIconButton>
@@ -72,6 +74,8 @@ function activeAllTrambusLine() {
         type="button"
         :class="{ 'rounded-l-lg': !isTrambusButtonVisible }"
         class="px-3 py-3 border border-gray-200 bg-white text-gray-900 inline-flex items-center"
+        titleButton="Afficher les lignes de métros"
+        ariaLabelButton="Afficher les lignes de métros sur la carte"
       >
         <IconMetro :active="layerStore.visibilities.metro"></IconMetro>
       </UiIconButton>
@@ -80,6 +84,8 @@ function activeAllTrambusLine() {
         :active="layerStore.visibilities.bus"
         type="button"
         class="border-t px-3 py-3 border-b border-gray-200 bg-white text-gray-900 inline-flex items-center"
+        titleButton="Afficher les lignes de bus"
+        ariaLabelButton="Afficher les lignes de bus sur la carte"
       >
         <IconBus :active="layerStore.visibilities.bus"></IconBus>
       </UiIconButton>
@@ -88,6 +94,8 @@ function activeAllTrambusLine() {
         :active="layerStore.visibilities.bike"
         type="button"
         class="rounded-r-md px-3 py-3 border border-gray-200 bg-white text-gray-900 inline-flex items-center"
+        titleButton="Afficher les pistes cyclables"
+        ariaLabelButton="Afficher les pistes cyclables sur la carte"
       >
         <IconVelo :active="layerStore.visibilities.bike"></IconVelo>
       </UiIconButton>

--- a/src/components/map/HeadToolbarTrambus.vue
+++ b/src/components/map/HeadToolbarTrambus.vue
@@ -51,7 +51,7 @@ function activeAllTrambusLine() {
 </script>
 
 <template>
-  <div class="absolute right-2 top-2 z-10 flex [&>*]:m-1">
+  <div class="absolute right-2 top-2 z-10 flex [&>*]:m-1" id="head-toolbar">
     <div
       class="inline-flex shadow-sm rounded-md"
       role="group"

--- a/src/components/map/aboveMap/LabelLine.vue
+++ b/src/components/map/aboveMap/LabelLine.vue
@@ -44,7 +44,12 @@ const getBgColorLine = (line: string) => {
 </script>
 
 <template>
-  <div class="absolute" :style="positionStyle" v-if="props.lines.length > 0">
+  <div
+    class="absolute"
+    :style="positionStyle"
+    v-if="props.lines.length > 0"
+    aria-hidden="true"
+  >
     <div class="flex p-2 round-md">
       <div
         v-for="line in props.lines"

--- a/src/components/map/buttons/LoginButtons.vue
+++ b/src/components/map/buttons/LoginButtons.vue
@@ -6,7 +6,7 @@ function getUserLog() {
 }
 </script>
 <template>
-  <UiIconButton class="rounded-full px-0 py-0">
+  <UiIconButton class="rounded-full px-0 py-0" titleButton="Espace mon compte">
     <div class="w-3/4 h-3/4 border border-black rounded-full flex mx-auto">
       <div v-if="getUserLog()" class="container my-auto">
         {{ getUserLog() }}

--- a/src/components/map/buttons/NavigationButtons.vue
+++ b/src/components/map/buttons/NavigationButtons.vue
@@ -63,19 +63,35 @@ const heightClass = computed(() => {
       class="rounded-lg"
       @click="router.push('/home')"
       v-show="shouldDisplayHomeButton()"
-      ><IconHome
-    /></UiIconButton>
+      titleButton="Revenir à l'accueil"
+    >
+      <IconHome />
+    </UiIconButton>
     <div class="flex flex-col zoom-buttons text-2xl [&>*]:p-2" role="group">
-      <UiIconButton class="rounded-t-lg" @click="() => zoom(false)">
+      <UiIconButton
+        class="rounded-t-lg"
+        @click="() => zoom(false)"
+        ariaLabelButton="Zoom avant sur la carte"
+      >
         <IconPlus />
       </UiIconButton>
-      <UiIconButton class="rounded-b-lg" @click="() => zoom(true)">
+      <UiIconButton
+        class="rounded-b-lg"
+        @click="() => zoom(true)"
+        ariaLabelButton="Zoom arrière sur la carte"
+      >
         <IconMinus />
       </UiIconButton>
     </div>
-    <UiIconButton class="font-semibold rounded-lg" @click="toggle3DMap">{{
-      map3dStore.is3D() ? '2D' : '3D'
-    }}</UiIconButton>
+    <UiIconButton
+      class="font-semibold rounded-lg"
+      @click="toggle3DMap"
+      :ariaLabelButton="
+        map3dStore.is3D() ? 'Passer la carte en 2D' : 'Passer la carte en 3D'
+      "
+    >
+      {{ map3dStore.is3D() ? '2D' : '3D' }}
+    </UiIconButton>
     <CompassComponent v-if="map3dStore.is3D()" />
   </div>
 </template>

--- a/src/components/ui/UiLineDescription.vue
+++ b/src/components/ui/UiLineDescription.vue
@@ -20,18 +20,21 @@ const props = defineProps({
 })
 </script>
 <template>
-  <div class="flex items-center px-0 py-3 gap-3 font-dm-sans">
+  <button
+    class="flex items-center px-0 py-3 gap-3 font-dm-sans"
+    :aria-label="`Ligne ${props.line} : de la station ${props.start} à la station ${props.end}.`"
+  >
     <IconLine :line="line" :size="'xl'"></IconLine>
     <div class="flex flex-col items-start p-0 grow">
-      <div class="text-base font-bold">
+      <div class="text-base font-bold" aria-hidden="true">
         {{ props.name }}
       </div>
       <div class="flex items-center p-0 gap-2">
-        <div class="text-sm font-normal text-neutral-800">
+        <div class="text-sm font-normal text-neutral-800" aria-hidden="true">
           {{ props.start }}
         </div>
         <IconTwoDirectionArrow></IconTwoDirectionArrow>
-        <div class="text-sm font-normal text-neutral-800">
+        <div class="text-sm font-normal text-neutral-800" aria-hidden="true">
           {{ props.end }}
         </div>
       </div>
@@ -39,11 +42,12 @@ const props = defineProps({
     <div
       class="flex flex-col items-start p-0 px-3 py-2 border border-slate-200 rounded"
       v-show="props.duration"
+      aria-hidden="true"
     >
       <div class="text-xs text-neutral-700 font-normal">Toutes les</div>
       <div class="font-bold text-sm text-neutral-800">
         {{ props.frequency }} min
       </div>
     </div>
-  </div>
+  </button>
 </template>

--- a/src/components/ui/UiMap.vue
+++ b/src/components/ui/UiMap.vue
@@ -13,7 +13,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="mapContainer" class="h-full w-full"></div>
+  <div ref="mapContainer" class="h-full w-full" aria-hidden="true"></div>
 </template>
 <style scoped>
 :deep(.mapElement) {

--- a/src/components/ui/UiPanelControlButton.vue
+++ b/src/components/ui/UiPanelControlButton.vue
@@ -17,6 +17,10 @@ const props = defineProps({
     type: String as PropType<AnchorPosition>,
     required: true,
   },
+  ariaLabelButton: {
+    type: String,
+    default: '',
+  },
 })
 
 const arrowIcon = computed(() => {
@@ -64,6 +68,7 @@ const styleClass = computed(() => {
   <button
     class="flex justify-center items-center gap-4 bg-white shadow"
     :class="styleClass"
+    :aria-label="ariaLabelButton"
   >
     <img :src="arrowIcon" />
   </button>

--- a/src/components/ui/UiPhotoGalery.vue
+++ b/src/components/ui/UiPhotoGalery.vue
@@ -29,6 +29,7 @@ function clickImage(photo: string) {
       :is-open="props.galleryShown"
       :anchor-position="'bottom'"
       @click="sendEvent"
+      ariaLabelButton="Afficher les images de la métropole de Rennes"
     ></UiPanelControlButton>
     <div
       class="flex flex-row items-start p-3 gap-3 w-auto h-56 bg-white rounded-l-xl rounded-r-xl rounded-t-none rounded-b-none"
@@ -40,6 +41,7 @@ function clickImage(photo: string) {
         :src="photo"
         class="w-64 h-52"
         @click="clickImage(photo)"
+        alt="''"
       />
     </div>
   </div>

--- a/src/components/ui/UiPhotoGalery.vue
+++ b/src/components/ui/UiPhotoGalery.vue
@@ -7,7 +7,7 @@ const emit = defineEmits(['toggleEvent', 'clickImage'])
 const props = defineProps({
   galleryShown: {
     type: Boolean,
-    default: true,
+    default: false,
   },
   photos: {
     type: Array as PropType<string[]>,

--- a/src/components/ui/UiTravelTime.vue
+++ b/src/components/ui/UiTravelTime.vue
@@ -32,34 +32,55 @@ const containerStyle = computed(() => {
 })
 </script>
 <template>
-  <div
+  <li
     class="flex items-center px-3 py-0 gap-2.5 rounded font-dm-sans hover:bg-white hover:border-slate-600 border"
     :class="containerStyle"
     :id="props.lineNumber + ':' + props.startStation + '-' + props.endStation"
   >
-    <div class="flex flex-col justify-center items-start pt-3 pr-3 pb-3 pl-0">
+    <div
+      class="flex flex-col justify-center items-start pt-3 pr-3 pb-3 pl-0"
+      :aria-label="
+        'Pour la ligne ' +
+        props.lineNumber +
+        ' entre la station' +
+        props.startStation +
+        ' et la station' +
+        props.endStation +
+        ' le temps de parcours est de ' +
+        props.newDuration +
+        ' minutes au lieu de ' +
+        props.oldDuration +
+        ' minutes'
+      "
+    >
       <div class="flex items-center px-0.5 py-0 gap-1 rounded">
-        <div class="font-bold text-base leading-5">
+        <div class="font-bold text-base leading-5" aria-hidden="true">
           {{ props.newDuration }} min
         </div>
       </div>
       <div class="flex flex-col items-start p-0 gap-1">
-        <div class="font-normal text-xs leading-4 text-neutral-500">
+        <div
+          class="font-normal text-xs leading-4 text-neutral-500"
+          aria-hidden="true"
+        >
           au lieu de {{ props.oldDuration }}
         </div>
       </div>
     </div>
     <IconLineArrow :lineNumber="props.lineNumber"></IconLineArrow>
     <div class="flex flex-col items-start p-0 gap-1 grow">
-      <div class="flex flex-col justify-center items-start p-0 gap-1.5">
+      <div
+        class="flex flex-col justify-center items-start p-0 gap-1.5"
+        aria-hidden="true"
+      >
         <div class="font-medium text-sm leading-5">
           {{ props.startStation }}
         </div>
-        <div class="font-medium text-sm leading-5">
+        <div class="font-medium text-sm leading-5" aria-hidden="true">
           {{ props.endStation }}
         </div>
       </div>
     </div>
     <IconLine :line="lineNumber" :size="'l'"></IconLine>
-  </div>
+  </li>
 </template>

--- a/src/components/ui/icons/IconCircleText.vue
+++ b/src/components/ui/icons/IconCircleText.vue
@@ -43,7 +43,11 @@ const textStyle = computed(() => {
     class="flex items-center rounded-full justify-center"
     :class="circleStyle"
   >
-    <div class="font-dm-sans font-bold text-white items-end" :class="textStyle">
+    <div
+      class="font-dm-sans font-bold text-white items-end"
+      :class="textStyle"
+      aria-hidden="true"
+    >
       {{ text }}
     </div>
   </div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -46,7 +46,5 @@ onMounted(() => {
       class="grow border-b border-neutral-300"
     ></LineDescriptions>
   </section>
-  <footer id="footer">
-    <FooterArea></FooterArea>
-  </footer>
+  <FooterArea></FooterArea>
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -10,13 +10,12 @@ import { useViewsStore } from '@/stores/views'
 import { useMap3dStore } from '@/stores/map'
 import { useLineInteractionStore } from '@/stores/interactionMap'
 import { FooterArea } from '@sigrennesmetropole/cooperation_jn_common_ui'
-import { usePanelsStore } from '@/stores/panels'
+import SkipLinksHome from '@/components/accessibility/SkipLinksHome.vue'
 
 const layerStore = useLayersStore()
 const viewStore = useViewsStore()
 const map3dStore = useMap3dStore()
 const lineInteractionStore = useLineInteractionStore()
-const panelsStore = usePanelsStore()
 
 onMounted(() => {
   viewStore.setHomeAsCurrentView()
@@ -31,13 +30,23 @@ onMounted(() => {
     bike: false,
     _traveltimeArrow: false,
   })
-  panelsStore.toggleGallery()
 })
 </script>
 
 <template>
-  <UiTrambusTitle></UiTrambusTitle>
-  <TravelTimes></TravelTimes>
-  <LineDescriptions class="grow border-b border-neutral-300"></LineDescriptions>
-  <FooterArea></FooterArea>
+  <SkipLinksHome></SkipLinksHome>
+  <section id="reseau-trambus" class="flex flex-col p-0 gap-3 font-dm-sans">
+    <UiTrambusTitle></UiTrambusTitle>
+  </section>
+  <section id="travel-times" class="flex flex-col gap-2">
+    <TravelTimes></TravelTimes>
+  </section>
+  <section id="line-descriptions">
+    <LineDescriptions
+      class="grow border-b border-neutral-300"
+    ></LineDescriptions>
+  </section>
+  <footer id="footer">
+    <FooterArea></FooterArea>
+  </footer>
 </template>


### PR DESCRIPTION
GSREN3D-292 : Accessibility home

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-292

### Description

First merge this PR on common: https://github.com/sigrennesmetropole/cooperation_jn_common_ui/pull/18

### Screenshots

Here it's hard explain what the code do. So, i add 2 videos:
- use only tab key 
- use of voice over (NVDA on windows)

**Navigation only with tab key**
The user can access to all link with tab and press enter to press button

https://user-images.githubusercontent.com/121813008/222761966-aaf08103-44aa-4bae-afd5-b7d9c0f3e2b4.mp4


**Navigation with NVDA**
On the begin of page , the skip links is use to jump some element .
The user can jump to :
- Section "Temps de parcours théorique"
- Section "Les nouvelles lignes"
- Footer 
- Navigation header
https://user-images.githubusercontent.com/121813008/222765406-2c4d530e-dcf5-4cf1-ba5e-88d6b40b5d18.mp4

For exemple, in the video below i use skip link to go to section "Les nouvelles lignes"
NVDA read only use full information for this section. The div was replace by ul , li  and user can click on button to go on the line page

https://user-images.githubusercontent.com/121813008/222768030-c11b6876-81cd-4980-a0bd-80b1a6fac457.mp4


