### PR TITLE
Add tag with commit hash on docker image for PR

### DIFF
--- a/.github/workflows/lint-build-push.yml
+++ b/.github/workflows/lint-build-push.yml
@@ -43,6 +43,7 @@ jobs:
             type=ref,enable=true,priority=600,prefix=,suffix=,event=tag
             # pull request event
             type=ref,enable=true,priority=600,prefix=pr-,suffix=,event=pr
+            type=sha,enable=true,priority=600,prefix=pr-,suffix=,event=pr
             # set latest tag for default branch
             type=sha,enable=true,priority=600,prefix=,suffix=,enable={{is_default_branch}}
 


### PR DESCRIPTION
### Description

We need a way to identify new image if a new commit is pushed to a PR, by adding the commit hash to the docker tag we can identify new image
